### PR TITLE
Fix Meetup #549 image extension (.avif → .png)

### DIFF
--- a/_meetups/549.md
+++ b/_meetups/549.md
@@ -25,7 +25,7 @@ venue:
 youtubeID:
 eventUrl: https://guild.host/events/civic-meetup-549-canada-loecxa
 booker:
-image: hacknight_549.avif
+image: hacknight_549.png
 tags:
   - type/meetup
 ---


### PR DESCRIPTION
Meetup #549's front matter (`_meetups/549.md`) declared `image: hacknight_549.avif`, but the actual source file is `hacknight_549.png`. `jekyll_picture_tag` could not find the `.avif` source, emitted a build warning, and produced a broken image:

```
Jekyll Picture Tag Warning: JPT Could not find .../archives/images/events/hacknight_549.avif. Your site will have broken images. Continuing.
```

This points the field at the existing `.png` source. It's the only `.avif` reference in the collection (429 `.jpg`, 22 `.png`, this lone `.avif`).

Fixes the site-side warning tracked in CivicTechTO/civictech.ca#141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)